### PR TITLE
Fix for #35

### DIFF
--- a/bootstrap-iconpicker/js/bootstrap-iconpicker.js
+++ b/bootstrap-iconpicker/js/bootstrap-iconpicker.js
@@ -193,16 +193,16 @@
         var op = this.options;
         var total_pages = this.totalPages();
         if (page === 1) { 
-            op.table.find('.btn-previous').addClass('disabled');
+            op.table.find('.btn-previous').addClass('disabled').prop('disabled',true);
         }
         else {
-            op.table.find('.btn-previous').removeClass('disabled');
+            op.table.find('.btn-previous').removeClass('disabled').removeProp('disabled');
         }
         if (page === total_pages || total_pages === 0) { 
-            op.table.find('.btn-next').addClass('disabled');
+            op.table.find('.btn-next').addClass('disabled').prop('disabled',true);
         }
         else {
-            op.table.find('.btn-next').removeClass('disabled');
+            op.table.find('.btn-next').removeClass('disabled').removeProp('disabled');
         }
     };
     


### PR DESCRIPTION
Fixing navigation buttons disabled state to make it compatible with Bootstrap 3.3.5. (Alternative solution is to turn this buttons into "a" links)
